### PR TITLE
feat: 升级node版本

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ branding:
   icon: 'cloud'
   color: 'red'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
根据官方的提示，需要升级 actions 的node 版本到 20 https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 